### PR TITLE
chore: Fix vault typo on README and zsh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PS1='[\u@\h \W $(vault_ps1)]\$ '
 
 If you want to stop showing vault address on your prompt string temporarily
 run `vaultoff`. To disable the prompt for all shell sessions, run `vaultoff -g`.
-You can enable it again in the current shell by running `vaulteon`, and globally
+You can enable it again in the current shell by running `vaulton`, and globally
 with `vaulton -g`.
 
 ```

--- a/vault-ps1.plugin.zsh
+++ b/vault-ps1.plugin.zsh
@@ -127,7 +127,7 @@ _vault_ps1_color_bg() {
     elif [[ $VAULT_PS1_BG_CODE -ge 0 ]] && [[ $VAULT_PS1_BG_CODE -le 256 ]]; then
       VAULT_PS1_BG_CODE="\033[48;5;${VAULT_PS1_BG_CODE}m"
     else
-      AVULT_PS1_BG_CODE="${DEFAULT_BG}"
+      VAULT_PS1_BG_CODE="${DEFAULT_BG}"
     fi
   fi
   echo ${OPEN_ESC}${VAULT_PS1_BG_CODE}${CLOSE_ESC}


### PR DESCRIPTION
Fix typos on the `README.md` and `vault-ps1.plugin.zsh` files.